### PR TITLE
Adds FromPrimitive for ZVT error codes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +986,8 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "num-derive",
+ "num-traits",
  "pretty-hex",
  "rstest",
  "tokio",

--- a/zvt/Cargo.toml
+++ b/zvt/Cargo.toml
@@ -21,6 +21,8 @@ async-stream = "0.3.5"
 chrono = "0.4.24"
 futures = "0.3.28"
 log = "0.4.19"
+num-derive = "0.4.1"
+num-traits = "0.2.17"
 pretty-hex = "0.4.0"
 tokio = { version = "1.29.1", features = ["net", "io-util", "rt-multi-thread", "macros"] }
 tokio-stream = "0.1.14"

--- a/zvt/src/constants.rs
+++ b/zvt/src/constants.rs
@@ -1,4 +1,7 @@
+use num_derive::FromPrimitive;
+
 /// Messages as defined under chapter 10.
+#[derive(Debug, PartialEq, FromPrimitive)]
 #[repr(u8)]
 pub enum ErrorMessages {
     CardNotReadable = 0x64,


### PR DESCRIPTION
This makes handling them in code easier - you once check if the enum can be created from the integer, then you have all the guarantees of a Rust enum.